### PR TITLE
Update composer config for FluentDOM v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     },
     "require": {
-        "fluentdom/fluentdom": "7.x",
-        "carica/phpcss": "~0.5"
+        "fluentdom/fluentdom": ">=7.0",
+        "carica/phpcss": "^1.0"
     },
     "autoload": {
         "files" : ["src/plugin.php"],

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7aae48eb8a066de6ceacc8e2dd58546f",
+    "content-hash": "243f694affffabc312c60332d9a9d7b6",
     "packages": [
         {
             "name": "carica/phpcss",
-            "version": "0.5.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ThomasWeinert/PhpCss.git",
-                "reference": "ae8b6da93bf05d41cde017115e3cf5f02138c121"
+                "reference": "f30cce2e4469d87e0d015ee24c28adb453cfd180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ThomasWeinert/PhpCss/zipball/ae8b6da93bf05d41cde017115e3cf5f02138c121",
-                "reference": "ae8b6da93bf05d41cde017115e3cf5f02138c121",
+                "url": "https://api.github.com/repos/ThomasWeinert/PhpCss/zipball/f30cce2e4469d87e0d015ee24c28adb453cfd180",
+                "reference": "f30cce2e4469d87e0d015ee24c28adb453cfd180",
                 "shasum": ""
             },
             "require": {
@@ -34,7 +34,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT license"
+                "MIT"
             ],
             "authors": [
                 {
@@ -43,27 +43,38 @@
                 }
             ],
             "description": "An css selector parser and converter",
-            "time": "2018-04-02T15:31:38+00:00"
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/PhpCss/issues",
+                "source": "https://github.com/ThomasWeinert/PhpCss/tree/master"
+            },
+            "time": "2018-06-27T15:14:42+00:00"
         },
         {
             "name": "fluentdom/fluentdom",
-            "version": "7.0.0",
+            "version": "7.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FluentDOM/FluentDOM.git",
-                "reference": "fda8452ef698d1ae644d3938513b33d9c3d86eb7"
+                "url": "https://github.com/ThomasWeinert/FluentDOM.git",
+                "reference": "bb9f9eed9965cb407ec74a441d3ca77d5ae53ef5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FluentDOM/FluentDOM/zipball/fda8452ef698d1ae644d3938513b33d9c3d86eb7",
-                "reference": "fda8452ef698d1ae644d3938513b33d9c3d86eb7",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM/zipball/bb9f9eed9965cb407ec74a441d3ca77d5ae53ef5",
+                "reference": "bb9f9eed9965cb407ec74a441d3ca77d5ae53ef5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "php": ">=7.0"
             },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*"
+            },
             "suggest": {
+                "ext-json": "JSON support, needed for several loaders/serializers",
                 "ext-xmlreader": "XMLReader, XML pull parser, read large XMLs",
                 "ext-xmlwriter": "XMLWriter, Write large XMLs",
                 "fluentdom/css-selector": "Allows to use css selectors."
@@ -97,7 +108,11 @@
                 "jquery",
                 "xml"
             ],
-            "time": "2017-10-01T10:41:43+00:00"
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/FluentDOM/issues",
+                "source": "https://github.com/ThomasWeinert/FluentDOM/tree/7.4.0"
+            },
+            "time": "2019-08-18T14:30:38+00:00"
         }
     ],
     "packages-dev": [],
@@ -110,5 +125,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.0"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR allows this library to work with FluentDOM v8 -- currently, composer cannot resolve FluentDOM v8 + this library @ v1.2.0 since the 7.x specified is too restrictive.